### PR TITLE
Starting the wrappers implementations with a new API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     rev: 6.3.0
     hooks:
       - id: pydocstyle
-        exclude: ^(tests/)|(docs/)|(setup.py)|(examples/)|(crazy_rl/mono_agent/)|(learning/)
+        exclude: ^(tests/)|(docs/)|(setup.py)|(examples/)|(crazy_rl/mono_agent/)|(learning/)|(crazy_rl/utils/jax_wrappers)
         args:
           - --source
           - --explain

--- a/crazy_rl/multi_agent/jax/base_parallel_env.py
+++ b/crazy_rl/multi_agent/jax/base_parallel_env.py
@@ -43,10 +43,6 @@ class BaseParallelEnv:
         _compute_terminated: Computes if the game must be stopped because the agents crashed from a given state.
         _compute_truncation: Computes if the game must be stopped because it is too long from a given state.
         reset: Resets the environment in initial state.
-        auto_reset: Returns the State reinitialized if needed, else the actual State.
-        state_to_dict: Translates the State into a dict.
-        step_vmap: Used to vmap step, takes the values of the state and calls step with a new State object containing
-                   the state values.
         state: Returns a global observation (concatenation of all the agent locations and the target locations).
 
     There are also the following functions:

--- a/crazy_rl/multi_agent/jax/base_parallel_env.py
+++ b/crazy_rl/multi_agent/jax/base_parallel_env.py
@@ -98,53 +98,9 @@ class BaseParallelEnv:
         """Resets the environment in initial state. Must be implemented in a subclass."""
         raise NotImplementedError
 
-    def auto_reset(self, **state) -> State:
-        """Returns the State reinitialized if needed, else the actual State. Must be implemented in a subclass.
-
-        The values contained by State are passed in argument and used like a dictionary
-        because auto_reset is meant to be used by vmap and vmap doesn't accept objects.
-
-        This function handles states like a dictionary, see also the pydoc of step_vmap.
-        """
-        raise NotImplementedError
-
-    def step_vmap(self, action: jnp.ndarray, key: jnp.ndarray, **state_val) -> State:
-        """Used to vmap step.
-
-         Takes the values of the state and calls step with a new State object containing
-         the state values. Must be implemented in a subclass.
-
-         JAX's vmap cannot operate on array-of-structs, but can operate on struct-of-arrays,
-         so the states actually contain array of arrays after vmap. Our solution to this is
-         to convert the struct into a dictionary of array of arrays and plug it into the vmapped
-         function as kwargs. This way, each value of the kwargs (the state members) will be
-         processed as a regular array.
-
-        Args:
-            action: 2D array containing the x, y, z action for each drone.
-            key : JAX PRNG key.
-            **state_val: Different values contained in the State.
-        """
-        raise NotImplementedError
-
-    def state_to_dict(self, state: State) -> dict:
-        """Translates the State into a dict. Must be implemented in a subclass."""
-        raise NotImplementedError
-
     def state(self, state: State) -> jnp.ndarray:
         """Returns a global observation (concatenation of all the agent locations and target locations). Must be implemented in a subclass."""
         raise NotImplementedError
-
-    def state_vmap(self, **state_vals) -> jnp.ndarray:
-        """Used for extracting global state from a batch of states.
-
-        Args:
-            **state_vals: Kwargs containing the values of the states.
-
-        Returns:
-            A global observation (concatenation of all the agent locations and target locations).
-        """
-        return self.state(State(**state_vals))
 
     @partial(jit, static_argnums=(0,))
     def step(

--- a/crazy_rl/multi_agent/jax/catch/catch.py
+++ b/crazy_rl/multi_agent/jax/catch/catch.py
@@ -11,7 +11,7 @@ from jax import jit, random
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
-from crazy_rl.utils.jax_wrappers import AddIDToObs, LogWrapper, VecEnv
+from crazy_rl.utils.jax_wrappers import AddIDToObs, AutoReset, LogWrapper, VecEnv
 
 
 @jdc.pytree_dataclass
@@ -230,11 +230,12 @@ if __name__ == "__main__":
         env, num_agents
     )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
     env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
+    env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 
-    for i in range(100):
+    for i in range(10):
         key, *subkeys = random.split(key, num_agents + 1)
         actions = (
             jnp.array([env.action_space(agent_id).sample(jnp.stack(subkeys[agent_id])) for agent_id in range(env.num_drones)])
@@ -246,7 +247,11 @@ if __name__ == "__main__":
         key, *subkeys = random.split(key, num_envs + 1)
         obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
-        print(info)
+        # print("obs", obs)
+        # print("rewards", rewards)
+        print("term", term)
+        print("trunc", trunc)
+        print("info", info)
 
     # @jit
     # def body(i, states_key):

--- a/crazy_rl/multi_agent/jax/catch/catch.py
+++ b/crazy_rl/multi_agent/jax/catch/catch.py
@@ -15,7 +15,7 @@ from crazy_rl.utils.jax_wrappers import (
     AddIDToObs,
     AutoReset,
     LogWrapper,
-    NormalizeVecObservation,
+    NormalizeObservation,
     NormalizeVecReward,
     VecEnv,
 )
@@ -198,6 +198,7 @@ if __name__ == "__main__":
     key, *subkeys = random.split(key, num_envs + 1)
 
     # Wrappers
+    env = NormalizeObservation(env)
     env = AddIDToObs(
         env, num_agents
     )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
@@ -205,7 +206,6 @@ if __name__ == "__main__":
     env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
     env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
-    env = NormalizeVecObservation(env)
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 
@@ -226,65 +226,3 @@ if __name__ == "__main__":
         # print("term", term)
         print("trunc", trunc)
         # print("info", info)
-
-    # @jit
-    # def body(i, states_key):
-    #     """Body of the fori_loop of play.
-    #
-    #     Args:
-    #         i: number of the iteration.
-    #         states_key: a tuple containing states and key.
-    #     """
-    #     states, key = states_key
-    #
-    #     key, *subkeys = random.split(key, env.num_drones + 1)
-    #     actions = (
-    #         jnp.array(
-    #             [env.action_space(agent_id).sample(subkeys[agent_id]) for agent_id in range(env.num_drones)]
-    #         )
-    #         .flatten()
-    #         .repeat(num_envs)
-    #         .reshape((num_envs, env.num_drones, -1))
-    #     )
-    #
-    #     print(actions)
-    #
-    #     key, *subkeys = random.split(key, num_envs + 1)
-    #
-    #     states = vmapped_step(actions, jnp.stack(subkeys), **env.state_to_dict(states))
-    #
-    #     # where you would learn or add to buffer
-    #
-    #     states = vmapped_auto_reset(**env.state_to_dict(states))
-    #
-    #     return (states, key)
-    #
-    # @jit
-    # def play(key):
-    #     """Execution of the environment with random actions."""
-    #     key, *subkeys = random.split(key, num_envs + 1)
-    #
-    #     states = vmapped_reset(jnp.stack(subkeys))
-    #
-    #     states, key = jax.lax.fori_loop(0, 1000, body, (states, key))
-    #
-    #     return key, states
-    #
-    # key, states = play(key)  # compilation of the function
-    #
-    # durations = np.zeros(10)
-    #
-    # print("start")
-    #
-    # for i in range(10):
-    #     start = time.time()
-    #
-    #     key, states = play(key)
-    #
-    #     jax.block_until_ready(states)
-    #
-    #     end = time.time() - start
-    #
-    #     durations[i] = end
-    #
-    # print("durations : ", durations)

--- a/crazy_rl/multi_agent/jax/catch/catch.py
+++ b/crazy_rl/multi_agent/jax/catch/catch.py
@@ -11,7 +11,13 @@ from jax import jit, random
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
-from crazy_rl.utils.jax_wrappers import AddIDToObs, AutoReset, LogWrapper, VecEnv
+from crazy_rl.utils.jax_wrappers import (
+    AddIDToObs,
+    AutoReset,
+    LogWrapper,
+    NormalizeVecReward,
+    VecEnv,
+)
 
 
 @jdc.pytree_dataclass
@@ -232,10 +238,11 @@ if __name__ == "__main__":
     env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
     env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
+    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 
-    for i in range(10):
+    for i in range(201):
         key, *subkeys = random.split(key, num_agents + 1)
         actions = (
             jnp.array([env.action_space(agent_id).sample(jnp.stack(subkeys[agent_id])) for agent_id in range(env.num_drones)])
@@ -248,10 +255,10 @@ if __name__ == "__main__":
         obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
         # print("obs", obs)
-        # print("rewards", rewards)
-        print("term", term)
+        print("rewards", rewards)
+        # print("term", term)
         print("trunc", trunc)
-        print("info", info)
+        # print("info", info)
 
     # @jit
     # def body(i, states_key):

--- a/crazy_rl/multi_agent/jax/catch/catch.py
+++ b/crazy_rl/multi_agent/jax/catch/catch.py
@@ -1,17 +1,17 @@
 """Catch environment for Crazyflie 2. Each agent is supposed to learn to surround a common target point trying to escape."""
 
-import time
 from functools import partial
+from typing import Tuple
 from typing_extensions import override
 
 import jax
 import jax.numpy as jnp
 import jax_dataclasses as jdc
-import numpy as np
-from jax import jit, random, vmap
+from jax import jit, random
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
+from crazy_rl.utils.jax_wrappers import AddIDToObs, LogWrapper, VecEnv
 
 
 @jdc.pytree_dataclass
@@ -20,12 +20,6 @@ class State(State):
 
     agents_locations: jnp.ndarray  # a 2D array containing x,y,z coordinates of each agent, indexed from 0.
     timestep: int  # represents the number of steps already done in the game
-
-    observations: jnp.ndarray  # array containing the current observation of each agent
-    rewards: jnp.ndarray  # array containing the current reward of each agent
-    terminations: jnp.ndarray  # array of booleans which are True if the agents have crashed
-    truncations: jnp.ndarray  # array of booleans which are True if the game reaches 100 timesteps
-
     target_location: jnp.ndarray  # 2D array containing x,y,z coordinates of the common target
 
 
@@ -50,13 +44,9 @@ class Catch(BaseParallelEnv):
             size: Size of the map in meters
         """
         self.num_drones = num_drones
-
         self._target_location = init_target_location  # unique target location for all agents
-
         self.target_speed = target_speed
-
         self._init_flying_pos = init_flying_pos
-
         self.size = size
 
     @override
@@ -73,17 +63,14 @@ class Catch(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_obs(self, state: State) -> State:
-        return jdc.replace(
-            state,
-            observations=jnp.append(
-                # each row contains the location of one agent and the location of the target
-                jnp.column_stack((state.agents_locations, jnp.tile(state.target_location, (self.num_drones, 1)))),
-                # then we add agents_locations to each row without the agent which is already in the row
-                # and make it only one dimension
-                jnp.array([jnp.delete(state.agents_locations, agent, axis=0).flatten() for agent in range(self.num_drones)]),
-                axis=1,
-            ),
+    def _compute_obs(self, state: State) -> jnp.ndarray:
+        return jnp.append(
+            # each row contains the location of one agent and the location of the target
+            jnp.column_stack((state.agents_locations, jnp.tile(state.target_location, (self.num_drones, 1)))),
+            # then we add agents_locations to each row without the agent which is already in the row
+            # and make it only one dimension
+            jnp.array([jnp.delete(state.agents_locations, agent, axis=0).flatten() for agent in range(self.num_drones)]),
+            axis=1,
         )
 
     @override
@@ -121,32 +108,31 @@ class Catch(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_reward(self, state: State) -> State:
+    def _compute_reward(self, state: State, terminations: jnp.ndarray, truncations: jnp.ndarray) -> jnp.ndarray:
         # Reward is the mean distance to the other agents plus a maximum value minus the distance to the target
-
-        return jdc.replace(
-            state,
-            rewards=jnp.any(state.truncations)
-            * (
-                # mean distance to the other agents
-                jnp.array(
-                    [
-                        jnp.sum(jnp.linalg.norm(state.agents_locations[agent] - state.agents_locations, axis=1))
-                        for agent in range(self.num_drones)
-                    ]
-                )
-                * 0.05
-                / (self.num_drones - 1)
-                # a maximum value minus the distance to the target
-                + 0.95 * (2 * self.size - jnp.linalg.norm(state.agents_locations - state.target_location, axis=1))
+        reward_close_to_target = 0.95 * (
+            2 * self.size - jnp.linalg.norm(state.agents_locations - state.target_location, axis=1)
+        )
+        reward_far_from_other_agents = (
+            jnp.array(
+                [
+                    jnp.sum(jnp.linalg.norm(state.agents_locations[agent] - state.agents_locations, axis=1))
+                    for agent in range(self.num_drones)
+                ]
             )
-            # negative reward if the drones crash
-            + jnp.any(state.terminations) * (1 - jnp.any(state.truncations)) * -10 * jnp.ones(self.num_drones),
+            * 0.05
+            / (self.num_drones - 1)
+        )
+        reward_crash = jnp.any(terminations) * -10 * jnp.ones(self.num_drones)
+
+        return (
+            jnp.any(truncations) * (reward_close_to_target + reward_far_from_other_agents)
+            + (1 - jnp.any(truncations)) * reward_crash
         )
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_terminated(self, state: State) -> State:
+    def _compute_terminated(self, state: State) -> jnp.ndarray:
         # collision with the ground and the target
         terminated = jnp.logical_or(
             state.agents_locations[:, 2] < 0.2, jnp.linalg.norm(state.agents_locations - state.target_location) < 0.2
@@ -160,27 +146,23 @@ class Catch(BaseParallelEnv):
                 jnp.logical_or(terminated[agent], jnp.any(jnp.logical_and(distances > 0.001, distances < 0.2)))
             )
 
-        return jdc.replace(state, terminations=jnp.any(terminated) * jnp.ones(self.num_drones))
+        return jnp.any(terminated) * jnp.ones(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_truncation(self, state: State) -> State:
-        return jdc.replace(state, truncations=(state.timestep == 100) * jnp.ones(self.num_drones))
+    def _compute_truncation(self, state: State) -> jnp.ndarray:
+        return (state.timestep == 100) * jnp.ones(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def reset(self, key: jnp.ndarray) -> State:
+    def reset(self, key: jnp.ndarray) -> Tuple[jnp.ndarray, dict, State]:
         state = State(
             agents_locations=self._init_flying_pos,
             timestep=0,
-            observations=jnp.array([]),
-            rewards=jnp.zeros(self.num_drones),
-            terminations=jnp.zeros(self.num_drones),
-            truncations=jnp.zeros(self.num_drones),
             target_location=jnp.array([self._target_location]),
         )
-        state = self._compute_obs(state)
-        return state
+        obs = self._compute_obs(state)
+        return obs, {}, state
 
     @override
     @partial(jit, static_argnums=(0,))
@@ -226,83 +208,104 @@ class Catch(BaseParallelEnv):
 if __name__ == "__main__":
     from jax.lib import xla_bridge
 
-    jax.config.update("jax_platform_name", "gpu")
+    jax.config.update("jax_platform_name", "cpu")
 
     print(xla_bridge.get_backend().platform)
 
-    parallel_env = Catch(
-        num_drones=5,
+    num_agents = 5
+    env = Catch(
+        num_drones=num_agents,
         init_flying_pos=jnp.array([[0.0, 0.0, 1.0], [2.0, 1.0, 1.0], [0.0, 1.0, 1.0], [2.0, 2.0, 1.0], [1.0, 0.0, 1.0]]),
         init_target_location=jnp.array([1.0, 1.0, 2.5]),
         target_speed=0.1,
     )
 
-    num_envs = 1000  # number of states in parallel
+    num_envs = 3  # number of states in parallel
     seed = 5  # test value
     key = random.PRNGKey(seed)
+    key, *subkeys = random.split(key, num_envs + 1)
 
-    vmapped_step = vmap(parallel_env.step_vmap)
-    vmapped_auto_reset = vmap(parallel_env.auto_reset)
-    vmapped_reset = vmap(parallel_env.reset)
+    # Wrappers
+    env = AddIDToObs(
+        env, num_agents
+    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
+    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
+    env = VecEnv(env)  # vmaps the env public methods
 
-    @jit
-    def body(i, states_key):
-        """Body of the fori_loop of play.
+    obs, info, state = env.reset(jnp.stack(subkeys))
 
-        Args:
-            i: number of the iteration.
-            states_key: a tuple containing states and key.
-        """
-        states, key = states_key
-
-        key, *subkeys = random.split(key, parallel_env.num_drones + 1)
+    for i in range(100):
+        key, *subkeys = random.split(key, num_agents + 1)
         actions = (
-            jnp.array(
-                [parallel_env.action_space(agent_id).sample(subkeys[agent_id]) for agent_id in range(parallel_env.num_drones)]
-            )
+            jnp.array([env.action_space(agent_id).sample(jnp.stack(subkeys[agent_id])) for agent_id in range(env.num_drones)])
             .flatten()
             .repeat(num_envs)
-            .reshape((num_envs, parallel_env.num_drones, -1))
+            .reshape((num_envs, env.num_drones, -1))
         )
-
-        print(actions)
-
+        global_state = env.state(state)
         key, *subkeys = random.split(key, num_envs + 1)
+        obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
-        states = vmapped_step(actions, jnp.stack(subkeys), **parallel_env.state_to_dict(states))
+        print(info)
 
-        # where you would learn or add to buffer
-
-        states = vmapped_auto_reset(**parallel_env.state_to_dict(states))
-
-        return (states, key)
-
-    @jit
-    def play(key):
-        """Execution of the environment with random actions."""
-        key, *subkeys = random.split(key, num_envs + 1)
-
-        states = vmapped_reset(jnp.stack(subkeys))
-
-        states, key = jax.lax.fori_loop(0, 1000, body, (states, key))
-
-        return key, states
-
-    key, states = play(key)  # compilation of the function
-
-    durations = np.zeros(10)
-
-    print("start")
-
-    for i in range(10):
-        start = time.time()
-
-        key, states = play(key)
-
-        jax.block_until_ready(states)
-
-        end = time.time() - start
-
-        durations[i] = end
-
-    print("durations : ", durations)
+    # @jit
+    # def body(i, states_key):
+    #     """Body of the fori_loop of play.
+    #
+    #     Args:
+    #         i: number of the iteration.
+    #         states_key: a tuple containing states and key.
+    #     """
+    #     states, key = states_key
+    #
+    #     key, *subkeys = random.split(key, env.num_drones + 1)
+    #     actions = (
+    #         jnp.array(
+    #             [env.action_space(agent_id).sample(subkeys[agent_id]) for agent_id in range(env.num_drones)]
+    #         )
+    #         .flatten()
+    #         .repeat(num_envs)
+    #         .reshape((num_envs, env.num_drones, -1))
+    #     )
+    #
+    #     print(actions)
+    #
+    #     key, *subkeys = random.split(key, num_envs + 1)
+    #
+    #     states = vmapped_step(actions, jnp.stack(subkeys), **env.state_to_dict(states))
+    #
+    #     # where you would learn or add to buffer
+    #
+    #     states = vmapped_auto_reset(**env.state_to_dict(states))
+    #
+    #     return (states, key)
+    #
+    # @jit
+    # def play(key):
+    #     """Execution of the environment with random actions."""
+    #     key, *subkeys = random.split(key, num_envs + 1)
+    #
+    #     states = vmapped_reset(jnp.stack(subkeys))
+    #
+    #     states, key = jax.lax.fori_loop(0, 1000, body, (states, key))
+    #
+    #     return key, states
+    #
+    # key, states = play(key)  # compilation of the function
+    #
+    # durations = np.zeros(10)
+    #
+    # print("start")
+    #
+    # for i in range(10):
+    #     start = time.time()
+    #
+    #     key, states = play(key)
+    #
+    #     jax.block_until_ready(states)
+    #
+    #     end = time.time() - start
+    #
+    #     durations[i] = end
+    #
+    # print("durations : ", durations)

--- a/crazy_rl/multi_agent/jax/catch/catch.py
+++ b/crazy_rl/multi_agent/jax/catch/catch.py
@@ -11,14 +11,7 @@ from jax import jit, random
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
-from crazy_rl.utils.jax_wrappers import (
-    AddIDToObs,
-    AutoReset,
-    LogWrapper,
-    NormalizeObservation,
-    NormalizeVecReward,
-    VecEnv,
-)
+from crazy_rl.utils.jax_wrappers import AutoReset, VecEnv
 
 
 @jdc.pytree_dataclass
@@ -198,14 +191,8 @@ if __name__ == "__main__":
     key, *subkeys = random.split(key, num_envs + 1)
 
     # Wrappers
-    env = NormalizeObservation(env)
-    env = AddIDToObs(
-        env, num_agents
-    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
-    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
     env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
-    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 

--- a/crazy_rl/multi_agent/jax/circle/circle.py
+++ b/crazy_rl/multi_agent/jax/circle/circle.py
@@ -1,16 +1,23 @@
 """Circle environment for Crazyflie 2. Each agent is supposed to learn to perform a circle around a target point."""
-import time
 from functools import partial
+from typing import Tuple
 from typing_extensions import override
 
 import jax
 import jax.numpy as jnp
 import jax_dataclasses as jdc
-import numpy as np
 from jax import jit, random, vmap
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
+from crazy_rl.utils.jax_wrappers import (
+    AddIDToObs,
+    AutoReset,
+    LogWrapper,
+    NormalizeObservation,
+    NormalizeVecReward,
+    VecEnv,
+)
 
 
 @jdc.pytree_dataclass
@@ -19,12 +26,6 @@ class State(State):
 
     agents_locations: jnp.ndarray  # a 2D array containing x,y,z coordinates of each agent, indexed from 0.
     timestep: int  # represents the number of steps already done in the game
-
-    observations: jnp.ndarray  # array containing the current observation of each agent
-    rewards: jnp.ndarray  # array containing the current reward of each agent
-    terminations: jnp.ndarray  # array of booleans which are True if the agents have crashed
-    truncations: jnp.ndarray  # array of booleans which are True if the game reaches 100 timesteps
-
     target_location: jnp.ndarray  # 2D array containing x,y,z coordinates of the target of each agent
 
 
@@ -85,8 +86,8 @@ class Circle(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_obs(self, state: State) -> State:
-        return jdc.replace(state, observations=vmap(jnp.append)(state.agents_locations, state.target_location))
+    def _compute_obs(self, state: State) -> jnp.ndarray:
+        return vmap(jnp.append)(state.agents_locations, state.target_location)
 
     @override
     @partial(jit, static_argnums=(0,))
@@ -99,71 +100,32 @@ class Circle(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_reward(self, state: State) -> State:
+    def _compute_reward(self, state: State, terminations: jnp.ndarray, truncations: jnp.ndarray) -> jnp.ndarray:
         # Reward is based on the Euclidean distance to the target point
 
-        return jdc.replace(state, rewards=-1 * jnp.linalg.norm(state.target_location - state.agents_locations, axis=1))
+        return -1 * jnp.linalg.norm(state.target_location - state.agents_locations, axis=1)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_terminated(self, state: State) -> State:
+    def _compute_terminated(self, state: State) -> jnp.ndarray:
         # the drones never crash. Terminations initialized to jnp.zeros() and then never changes
-        return state
+        return jnp.zeros(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_truncation(self, state: State) -> State:
-        return jdc.replace(state, truncations=(state.timestep == 100) * jnp.ones(self.num_drones))
+    def _compute_truncation(self, state: State) -> jnp.ndarray:
+        return (state.timestep == 100) * jnp.ones(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def reset(self, key: jnp.ndarray) -> State:
+    def reset(self, key: jnp.ndarray) -> Tuple[jnp.ndarray, dict, State]:
         state = State(
             agents_locations=self._init_flying_pos,
             timestep=0,
-            observations=jnp.array([]),
-            rewards=jnp.zeros(self.num_drones),
-            terminations=jnp.zeros(self.num_drones),
-            truncations=jnp.zeros(self.num_drones),
             target_location=jnp.copy(self.ref[0]),
         )
-        state = self._compute_obs(state)
-        return state
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def auto_reset(self, **state) -> State:
-        done = jnp.min(jnp.array([jnp.any(state["truncations"]) + jnp.any(state["terminations"]), 1]))
-
-        state = State(
-            agents_locations=done * self._init_flying_pos + (1 - done) * state["agents_locations"],
-            timestep=(1 - done) * state["timestep"],
-            observations=state["observations"],
-            rewards=(1 - done) * state["rewards"],
-            terminations=(1 - done) * state["terminations"],
-            truncations=(1 - done) * state["truncations"],
-            target_location=done * self.ref[0] + (1 - done) * state["target_location"],
-        )
-        state = self._compute_obs(state)
-        return state
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def state_to_dict(self, state: State) -> dict:
-        return {
-            "agents_locations": state.agents_locations,
-            "timestep": state.timestep,
-            "observations": state.observations,
-            "rewards": state.rewards,
-            "terminations": state.terminations,
-            "truncations": state.truncations,
-            "target_location": state.target_location,
-        }
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def step_vmap(self, action: jnp.ndarray, key: jnp.ndarray, **state_val) -> State:
-        return self.step(State(**state_val), action, key)
+        obs = self._compute_obs(state)
+        return obs, {}, state
 
     @override
     @partial(jit, static_argnums=(0,))
@@ -178,75 +140,44 @@ if __name__ == "__main__":
 
     print(xla_bridge.get_backend().platform)
 
-    parallel_env = Circle(
-        num_drones=5,
+    num_agents = 5
+    env = Circle(
+        num_drones=num_agents,
         init_flying_pos=jnp.array([[0.0, 0.0, 1.0], [2.0, 1.0, 1.0], [0.0, 1.0, 1.0], [2.0, 2.0, 1.0], [1.0, 0.0, 1.0]]),
         num_intermediate_points=100,
     )
-    num_envs = 1000  # number of states in parallel
+
+    num_envs = 3  # number of states in parallel
     seed = 5  # test value
     key = random.PRNGKey(seed)
+    key, *subkeys = random.split(key, num_envs + 1)
 
-    vmapped_step = vmap(parallel_env.step_vmap)
-    vmapped_auto_reset = vmap(parallel_env.auto_reset)
-    vmapped_reset = vmap(parallel_env.reset)
+    # Wrappers
+    env = NormalizeObservation(env)
+    env = AddIDToObs(
+        env, num_agents
+    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
+    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
+    env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
+    env = VecEnv(env)  # vmaps the env public methods
+    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
-    @jit
-    def body(i, states_key):
-        """Body of the fori_loop of play.
+    obs, info, state = env.reset(jnp.stack(subkeys))
 
-        Args:
-            i: number of the iteration.
-            states_key: a tuple containing states and key.
-        """
-        states, key = states_key
-
-        key, *subkeys = random.split(key, parallel_env.num_drones + 1)
+    for i in range(301):
+        key, *subkeys = random.split(key, num_agents + 1)
         actions = (
-            jnp.array(
-                [parallel_env.action_space(agent_id).sample(subkeys[agent_id]) for agent_id in range(parallel_env.num_drones)]
-            )
+            jnp.array([env.action_space(agent_id).sample(jnp.stack(subkeys[agent_id])) for agent_id in range(env.num_drones)])
             .flatten()
             .repeat(num_envs)
-            .reshape((num_envs, parallel_env.num_drones, -1))
+            .reshape((num_envs, env.num_drones, -1))
         )
-
+        global_state = env.state(state)
         key, *subkeys = random.split(key, num_envs + 1)
+        obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
-        states = vmapped_step(actions, jnp.stack(subkeys), **parallel_env.state_to_dict(states))
-
-        # where you would learn or add to buffer
-
-        states = vmapped_auto_reset(**parallel_env.state_to_dict(states))
-
-        return (states, key)
-
-    @jit
-    def play(key):
-        """Execution of the environment with random actions."""
-        key, *subkeys = random.split(key, num_envs + 1)
-
-        states = vmapped_reset(jnp.stack(subkeys))
-
-        states, key = jax.lax.fori_loop(0, 1000, body, (states, key))
-
-        return key, states
-
-    key, states = play(key)  # compilation of the function
-
-    durations = np.zeros(10)
-
-    print("start")
-
-    for i in range(10):
-        start = time.time()
-
-        key, states = play(key)
-
-        jax.block_until_ready(states)
-
-        end = time.time() - start
-
-        durations[i] = end
-
-    print("durations : ", durations)
+        # print("obs", obs)
+        print("rewards", rewards)
+        # print("term", term)
+        print("trunc", trunc)
+        # print("info", info)

--- a/crazy_rl/multi_agent/jax/circle/circle.py
+++ b/crazy_rl/multi_agent/jax/circle/circle.py
@@ -10,14 +10,7 @@ from jax import jit, random, vmap
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
-from crazy_rl.utils.jax_wrappers import (
-    AddIDToObs,
-    AutoReset,
-    LogWrapper,
-    NormalizeObservation,
-    NormalizeVecReward,
-    VecEnv,
-)
+from crazy_rl.utils.jax_wrappers import AutoReset, VecEnv
 
 
 @jdc.pytree_dataclass
@@ -153,14 +146,8 @@ if __name__ == "__main__":
     key, *subkeys = random.split(key, num_envs + 1)
 
     # Wrappers
-    env = NormalizeObservation(env)
-    env = AddIDToObs(
-        env, num_agents
-    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
-    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
     env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
-    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 

--- a/crazy_rl/multi_agent/jax/escort/escort.py
+++ b/crazy_rl/multi_agent/jax/escort/escort.py
@@ -11,14 +11,7 @@ from jax import jit, random
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
-from crazy_rl.utils.jax_wrappers import (
-    AddIDToObs,
-    AutoReset,
-    LogWrapper,
-    NormalizeObservation,
-    NormalizeVecReward,
-    VecEnv,
-)
+from crazy_rl.utils.jax_wrappers import AutoReset, VecEnv
 
 
 @jdc.pytree_dataclass
@@ -193,14 +186,8 @@ if __name__ == "__main__":
     key, *subkeys = random.split(key, num_envs + 1)
 
     # Wrappers
-    env = NormalizeObservation(env)
-    env = AddIDToObs(
-        env, num_agents
-    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
-    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
     env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
-    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 

--- a/crazy_rl/multi_agent/jax/escort/escort.py
+++ b/crazy_rl/multi_agent/jax/escort/escort.py
@@ -1,17 +1,24 @@
 """Escort environment for Crazyflie 2. Each agent is supposed to learn to surround a common target point moving to one point to another."""
 
-import time
 from functools import partial
+from typing import Tuple
 from typing_extensions import override
 
 import jax
 import jax.numpy as jnp
 import jax_dataclasses as jdc
-import numpy as np
-from jax import jit, random, vmap
+from jax import jit, random
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
+from crazy_rl.utils.jax_wrappers import (
+    AddIDToObs,
+    AutoReset,
+    LogWrapper,
+    NormalizeObservation,
+    NormalizeVecReward,
+    VecEnv,
+)
 
 
 @jdc.pytree_dataclass
@@ -20,12 +27,6 @@ class State(State):
 
     agents_locations: jnp.ndarray  # a 2D array containing x,y,z coordinates of each agent, indexed from 0.
     timestep: int  # represents the number of steps already done in the game
-
-    observations: jnp.ndarray  # array containing the current observation of each agent
-    rewards: jnp.ndarray  # array containing the current reward of each agent
-    terminations: jnp.ndarray  # array of booleans which are True if the agents have crashed
-    truncations: jnp.ndarray  # array of booleans which are True if the game reaches 100 timesteps
-
     target_location: jnp.ndarray  # 2D array containing x,y,z coordinates of the common target
 
 
@@ -85,17 +86,14 @@ class Escort(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_obs(self, state: State) -> State:
-        return jdc.replace(
-            state,
-            observations=jnp.append(
-                # each row contains the location of one agent and the location of the target
-                jnp.column_stack((state.agents_locations, jnp.tile(state.target_location, (self.num_drones, 1)))),
-                # then we add agents_locations to each row without the agent which is already in the row
-                # and make it only one dimension
-                jnp.array([jnp.delete(state.agents_locations, agent, axis=0).flatten() for agent in range(self.num_drones)]),
-                axis=1,
-            ),
+    def _compute_obs(self, state: State) -> jnp.ndarray:
+        return jnp.append(
+            # each row contains the location of one agent and the location of the target
+            jnp.column_stack((state.agents_locations, jnp.tile(state.target_location, (self.num_drones, 1)))),
+            # then we add agents_locations to each row without the agent which is already in the row
+            # and make it only one dimension
+            jnp.array([jnp.delete(state.agents_locations, agent, axis=0).flatten() for agent in range(self.num_drones)]),
+            axis=1,
         )
 
     @override
@@ -110,32 +108,32 @@ class Escort(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_reward(self, state: State) -> State:
+    def _compute_reward(self, state: State, terminations: jnp.ndarray, truncations: jnp.ndarray) -> jnp.ndarray:
         # Reward is the mean distance to the other agents plus a maximum value minus the distance to the target
 
-        return jdc.replace(
-            state,
-            rewards=jnp.any(state.truncations)
-            * (
-                # mean distance to the other agents
-                jnp.array(
-                    [
-                        jnp.sum(jnp.linalg.norm(state.agents_locations[agent] - state.agents_locations, axis=1))
-                        for agent in range(self.num_drones)
-                    ]
-                )
-                * 0.05
-                / (self.num_drones - 1)
-                # a maximum value minus the distance to the target
-                + 0.95 * (2 * self.size - jnp.linalg.norm(state.agents_locations - state.target_location, axis=1))
+        reward_close_to_target = 0.95 * (
+            2 * self.size - jnp.linalg.norm(state.agents_locations - state.target_location, axis=1)
+        )
+        reward_far_from_other_agents = (
+            jnp.array(
+                [
+                    jnp.sum(jnp.linalg.norm(state.agents_locations[agent] - state.agents_locations, axis=1))
+                    for agent in range(self.num_drones)
+                ]
             )
-            # negative reward if the drones crash
-            + jnp.any(state.terminations) * (1 - jnp.any(state.truncations)) * -10 * jnp.ones(self.num_drones),
+            * 0.05
+            / (self.num_drones - 1)
+        )
+        reward_crash = jnp.any(terminations) * -10 * jnp.ones(self.num_drones)
+
+        return (
+            jnp.any(truncations) * (reward_close_to_target + reward_far_from_other_agents)
+            + (1 - jnp.any(truncations)) * reward_crash
         )
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_terminated(self, state: State) -> State:
+    def _compute_terminated(self, state: State) -> jnp.ndarray:
         # collision with the ground and the target
         terminated = jnp.logical_or(
             state.agents_locations[:, 2] < 0.2, jnp.linalg.norm(state.agents_locations - state.target_location) < 0.2
@@ -149,62 +147,23 @@ class Escort(BaseParallelEnv):
                 jnp.logical_or(terminated[agent], jnp.any(jnp.logical_and(distances > 0.001, distances < 0.2)))
             )
 
-        return jdc.replace(state, terminations=jnp.any(terminated) * jnp.ones(self.num_drones))
+        return jnp.any(terminated) * jnp.ones(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_truncation(self, state: State) -> State:
-        return jdc.replace(state, truncations=(state.timestep == 100) * jnp.ones(self.num_drones))
+    def _compute_truncation(self, state: State) -> jnp.ndarray:
+        return (state.timestep == 100) * jnp.ones(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def reset(self, key: jnp.ndarray) -> State:
+    def reset(self, key: jnp.ndarray) -> Tuple[jnp.ndarray, dict, State]:
         state = State(
             agents_locations=self._init_flying_pos,
             timestep=0,
-            observations=jnp.array([]),
-            rewards=jnp.zeros(self.num_drones),
-            terminations=jnp.zeros(self.num_drones),
-            truncations=jnp.zeros(self.num_drones),
             target_location=jnp.array([self._target_location]),
         )
-        state = self._compute_obs(state)
-        return state
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def auto_reset(self, **state) -> State:
-        done = jnp.min(jnp.array([jnp.any(state["truncations"]) + jnp.any(state["terminations"]), 1]))
-
-        state = State(
-            agents_locations=done * self._init_flying_pos + (1 - done) * state["agents_locations"],
-            timestep=(1 - done) * state["timestep"],
-            observations=state["observations"],
-            rewards=(1 - done) * state["rewards"],
-            terminations=(1 - done) * state["terminations"],
-            truncations=(1 - done) * state["truncations"],
-            target_location=done * self._target_location + (1 - done) * state["target_location"],
-        )
-        state = self._compute_obs(state)
-        return state
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def state_to_dict(self, state: State) -> dict:
-        return {
-            "agents_locations": state.agents_locations,
-            "timestep": state.timestep,
-            "observations": state.observations,
-            "rewards": state.rewards,
-            "terminations": state.terminations,
-            "truncations": state.truncations,
-            "target_location": state.target_location,
-        }
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def step_vmap(self, action: jnp.ndarray, key: jnp.ndarray, **state_val) -> State:
-        return self.step(State(**state_val), action, key)
+        obs = self._compute_obs(state)
+        return obs, {}, state
 
     @override
     @partial(jit, static_argnums=(0,))
@@ -219,8 +178,9 @@ if __name__ == "__main__":
 
     print(xla_bridge.get_backend().platform)
 
-    parallel_env = Escort(
-        num_drones=5,
+    num_agents = 5
+    env = Escort(
+        num_drones=num_agents,
         init_flying_pos=jnp.array([[0.0, 0.0, 1.0], [2.0, 1.0, 1.0], [0.0, 1.0, 1.0], [2.0, 2.0, 1.0], [1.0, 0.0, 1.0]]),
         init_target_location=jnp.array([1.0, 1.0, 2.5]),
         final_target_location=jnp.array([-2.0, -2.0, 3.0]),
@@ -230,67 +190,34 @@ if __name__ == "__main__":
     num_envs = 1000  # number of states in parallel
     seed = 5  # test value
     key = random.PRNGKey(seed)
+    key, *subkeys = random.split(key, num_envs + 1)
 
-    vmapped_step = vmap(parallel_env.step_vmap)
-    vmapped_auto_reset = vmap(parallel_env.auto_reset)
-    vmapped_reset = vmap(parallel_env.reset)
+    # Wrappers
+    env = NormalizeObservation(env)
+    env = AddIDToObs(
+        env, num_agents
+    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
+    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
+    env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
+    env = VecEnv(env)  # vmaps the env public methods
+    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
-    @jit
-    def body(i, states_key):
-        """Body of the fori_loop of play.
+    obs, info, state = env.reset(jnp.stack(subkeys))
 
-        Args:
-            i: number of the iteration.
-            states_key: a tuple containing states and key.
-        """
-        states, key = states_key
-
-        key, *subkeys = random.split(key, parallel_env.num_drones + 1)
+    for i in range(201):
+        key, *subkeys = random.split(key, num_agents + 1)
         actions = (
-            jnp.array(
-                [parallel_env.action_space(agent_id).sample(subkeys[agent_id]) for agent_id in range(parallel_env.num_drones)]
-            )
+            jnp.array([env.action_space(agent_id).sample(jnp.stack(subkeys[agent_id])) for agent_id in range(env.num_drones)])
             .flatten()
             .repeat(num_envs)
-            .reshape((num_envs, parallel_env.num_drones, -1))
+            .reshape((num_envs, env.num_drones, -1))
         )
-
+        global_state = env.state(state)
         key, *subkeys = random.split(key, num_envs + 1)
+        obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
-        states = vmapped_step(actions, jnp.stack(subkeys), **parallel_env.state_to_dict(states))
-
-        # where you would learn or add to buffer
-
-        states = vmapped_auto_reset(**parallel_env.state_to_dict(states))
-
-        return (states, key)
-
-    @jit
-    def play(key):
-        """Execution of the environment with random actions."""
-        key, *subkeys = random.split(key, num_envs + 1)
-
-        states = vmapped_reset(jnp.stack(subkeys))
-
-        states, key = jax.lax.fori_loop(0, 1000, body, (states, key))
-
-        return key, states
-
-    key, states = play(key)  # compilation of the function
-
-    durations = np.zeros(10)
-
-    print("start")
-
-    for i in range(10):
-        start = time.time()
-
-        key, states = play(key)
-
-        jax.block_until_ready(states)
-
-        end = time.time() - start
-
-        durations[i] = end
-
-    print("durations : ", durations)
+        # print("obs", obs)
+        print("rewards", rewards)
+        # print("term", term)
+        print("trunc", trunc)
+        # print("info", info)

--- a/crazy_rl/multi_agent/jax/hover/hover.py
+++ b/crazy_rl/multi_agent/jax/hover/hover.py
@@ -1,16 +1,23 @@
 """Hover environment for Crazyflies 2."""
-import time
 from functools import partial
+from typing import Tuple
 from typing_extensions import override
 
 import jax
 import jax.numpy as jnp
 import jax_dataclasses as jdc
-import numpy as np
 from jax import jit, random, vmap
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
+from crazy_rl.utils.jax_wrappers import (
+    AddIDToObs,
+    AutoReset,
+    LogWrapper,
+    NormalizeObservation,
+    NormalizeVecReward,
+    VecEnv,
+)
 
 
 @jdc.pytree_dataclass
@@ -19,11 +26,6 @@ class State(State):
 
     agents_locations: jnp.ndarray  # a 2D array containing x,y,z coordinates of each agent, indexed from 0.
     timestep: int  # represents the number of steps already done in the game
-
-    observations: jnp.ndarray  # array containing the current observation of each agent
-    rewards: jnp.ndarray  # array containing the current reward of each agent
-    terminations: jnp.ndarray  # array of booleans which are True if the agents have crashed
-    truncations: jnp.ndarray  # array of booleans which are True if the game reaches 100 timesteps
 
 
 class Hover(BaseParallelEnv):
@@ -63,8 +65,8 @@ class Hover(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_obs(self, state: State) -> State:
-        return jdc.replace(state, observations=vmap(jnp.append)(state.agents_locations, self._target_location))
+    def _compute_obs(self, state: State) -> jnp.ndarray:
+        return vmap(jnp.append)(state.agents_locations, self._target_location)
 
     @override
     @partial(jit, static_argnums=(0,))
@@ -73,66 +75,29 @@ class Hover(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_reward(self, state: State) -> State:
-        return jdc.replace(state, rewards=-1 * jnp.linalg.norm(self._target_location - state.agents_locations, axis=1))
+    def _compute_reward(self, state: State, terminations: jnp.ndarray, truncations: jnp.ndarray) -> jnp.ndarray:
+        return -1 * jnp.linalg.norm(self._target_location - state.agents_locations, axis=1)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_terminated(self, state: State) -> State:
+    def _compute_terminated(self, state: State) -> jnp.ndarray:
         # the drones never crash. Terminations initialized to jnp.zeros() and then never changes
-        return state
+        return jnp.zeros(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_truncation(self, state: State) -> State:
-        return jdc.replace(state, truncations=(state.timestep == 100) * jnp.ones(self.num_drones))
+    def _compute_truncation(self, state: State) -> jnp.ndarray:
+        return (state.timestep == 100) * jnp.ones(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def reset(self, key: jnp.ndarray) -> State:
+    def reset(self, key: jnp.ndarray) -> Tuple[jnp.ndarray, dict, State]:
         state = State(
             agents_locations=self._init_flying_pos,
             timestep=0,
-            observations=jnp.array([]),
-            rewards=jnp.zeros(self.num_drones),
-            terminations=jnp.zeros(self.num_drones),
-            truncations=jnp.zeros(self.num_drones),
         )
-        state = self._compute_obs(state)
-        return state
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def auto_reset(self, **state) -> State:
-        done = jnp.min(jnp.array([jnp.any(state["truncations"]) + jnp.any(state["terminations"]), 1]))
-
-        state = State(
-            agents_locations=done * self._init_flying_pos + (1 - done) * state["agents_locations"],
-            timestep=(1 - done) * state["timestep"],
-            observations=state["observations"],
-            rewards=(1 - done) * state["rewards"],
-            terminations=(1 - done) * state["terminations"],
-            truncations=(1 - done) * state["truncations"],
-        )
-        state = self._compute_obs(state)
-        return state
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def state_to_dict(self, state: State) -> dict:
-        return {
-            "agents_locations": state.agents_locations,
-            "timestep": state.timestep,
-            "observations": state.observations,
-            "rewards": state.rewards,
-            "terminations": state.terminations,
-            "truncations": state.truncations,
-        }
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def step_vmap(self, action: jnp.ndarray, key: jnp.ndarray, **state_val) -> State:
-        return self.step(State(**state_val), action, key)
+        obs = self._compute_obs(state)
+        return obs, {}, state
 
     @override
     @partial(jit, static_argnums=(0,))
@@ -147,75 +112,43 @@ if __name__ == "__main__":
 
     print(xla_bridge.get_backend().platform)
 
-    parallel_env = Hover(
-        num_drones=5,
+    num_agents = 5
+    env = Hover(
+        num_drones=num_agents,
         init_flying_pos=jnp.array([[0.0, 0.0, 1.0], [2.0, 1.0, 1.0], [0.0, 1.0, 1.0], [2.0, 2.0, 1.0], [1.0, 0.0, 1.0]]),
     )
 
     num_envs = 1000  # number of states in parallel
     seed = 5  # test value
     key = random.PRNGKey(seed)
+    key, *subkeys = random.split(key, num_envs + 1)
 
-    vmapped_step = vmap(parallel_env.step_vmap)
-    vmapped_auto_reset = vmap(parallel_env.auto_reset)
-    vmapped_reset = vmap(parallel_env.reset)
+    # Wrappers
+    env = NormalizeObservation(env)
+    env = AddIDToObs(
+        env, num_agents
+    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
+    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
+    env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
+    env = VecEnv(env)  # vmaps the env public methods
+    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
-    @jit
-    def body(i, states_key):
-        """Body of the fori_loop of play.
+    obs, info, state = env.reset(jnp.stack(subkeys))
 
-        Args:
-            i: number of the iteration.
-            states_key: a tuple containing states and key.
-        """
-        states, key = states_key
-
-        key, *subkeys = random.split(key, parallel_env.num_drones + 1)
+    for i in range(301):
+        key, *subkeys = random.split(key, num_agents + 1)
         actions = (
-            jnp.array(
-                [parallel_env.action_space(agent_id).sample(subkeys[agent_id]) for agent_id in range(parallel_env.num_drones)]
-            )
+            jnp.array([env.action_space(agent_id).sample(jnp.stack(subkeys[agent_id])) for agent_id in range(env.num_drones)])
             .flatten()
             .repeat(num_envs)
-            .reshape((num_envs, parallel_env.num_drones, -1))
+            .reshape((num_envs, env.num_drones, -1))
         )
-
+        global_state = env.state(state)
         key, *subkeys = random.split(key, num_envs + 1)
+        obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
-        states = vmapped_step(actions, jnp.stack(subkeys), **parallel_env.state_to_dict(states))
-
-        # where you would learn or add to buffer
-
-        states = vmapped_auto_reset(**parallel_env.state_to_dict(states))
-
-        return (states, key)
-
-    @jit
-    def play(key):
-        """Execution of the environment with random actions."""
-        key, *subkeys = random.split(key, num_envs + 1)
-
-        states = vmapped_reset(jnp.stack(subkeys))
-
-        states, key = jax.lax.fori_loop(0, 1000, body, (states, key))
-
-        return key, states
-
-    key, states = play(key)  # compilation of the function
-
-    durations = np.zeros(10)
-
-    print("start")
-
-    for i in range(10):
-        start = time.time()
-
-        key, states = play(key)
-
-        jax.block_until_ready(states)
-
-        end = time.time() - start
-
-        durations[i] = end
-
-    print("durations : ", durations)
+        # print("obs", obs)
+        print("rewards", rewards)
+        # print("term", term)
+        print("trunc", trunc)
+        # print("info", info)

--- a/crazy_rl/multi_agent/jax/hover/hover.py
+++ b/crazy_rl/multi_agent/jax/hover/hover.py
@@ -10,14 +10,7 @@ from jax import jit, random, vmap
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
-from crazy_rl.utils.jax_wrappers import (
-    AddIDToObs,
-    AutoReset,
-    LogWrapper,
-    NormalizeObservation,
-    NormalizeVecReward,
-    VecEnv,
-)
+from crazy_rl.utils.jax_wrappers import AutoReset, VecEnv
 
 
 @jdc.pytree_dataclass
@@ -124,14 +117,8 @@ if __name__ == "__main__":
     key, *subkeys = random.split(key, num_envs + 1)
 
     # Wrappers
-    env = NormalizeObservation(env)
-    env = AddIDToObs(
-        env, num_agents
-    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
-    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
     env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
-    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 

--- a/crazy_rl/multi_agent/jax/surround/surround.py
+++ b/crazy_rl/multi_agent/jax/surround/surround.py
@@ -11,14 +11,7 @@ from jax import jit, random
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
-from crazy_rl.utils.jax_wrappers import (
-    AddIDToObs,
-    AutoReset,
-    LogWrapper,
-    NormalizeObservation,
-    NormalizeVecReward,
-    VecEnv,
-)
+from crazy_rl.utils.jax_wrappers import AutoReset, VecEnv
 
 
 @jdc.pytree_dataclass
@@ -169,14 +162,8 @@ if __name__ == "__main__":
     key, *subkeys = random.split(key, num_envs + 1)
 
     # Wrappers
-    env = NormalizeObservation(env)
-    env = AddIDToObs(
-        env, num_agents
-    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
-    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
     env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
-    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 

--- a/crazy_rl/multi_agent/jax/surround/surround.py
+++ b/crazy_rl/multi_agent/jax/surround/surround.py
@@ -1,17 +1,24 @@
 """Surround environment for Crazyflie 2. Each agent is supposed to learn to surround a common target point."""
-import time
 from functools import partial
+from typing import Tuple
 from typing_extensions import override
 
 import jax
 import jax.numpy as jnp
 import jax_dataclasses as jdc
-import numpy as np
 from gymnasium import spaces
-from jax import jit, random, vmap
+from jax import jit, random
 
 from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
 from crazy_rl.utils.jax_spaces import Box, Space
+from crazy_rl.utils.jax_wrappers import (
+    AddIDToObs,
+    AutoReset,
+    LogWrapper,
+    NormalizeObservation,
+    NormalizeVecReward,
+    VecEnv,
+)
 
 
 @jdc.pytree_dataclass
@@ -20,11 +27,6 @@ class State(State):
 
     agents_locations: jnp.ndarray  # a 2D array containing x,y,z coordinates of each agent, indexed from 0.
     timestep: int  # represents the number of steps already done in the game
-
-    observations: jnp.ndarray  # array containing the current observation of each agent
-    rewards: jnp.ndarray  # array containing the current reward of each agent
-    terminations: jnp.ndarray  # array of booleans which are True if the agents have crashed
-    truncations: jnp.ndarray  # array of booleans which are True if the game reaches 100 timesteps
 
 
 class Surround(BaseParallelEnv):
@@ -54,7 +56,7 @@ class Surround(BaseParallelEnv):
         self.size = size
 
     @override
-    def observation_space(self, agent: int) -> spaces.Space:
+    def observation_space(self, agent: int) -> Space:
         return spaces.Box(
             low=-self.size,
             high=self.size,
@@ -68,17 +70,14 @@ class Surround(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_obs(self, state: State) -> State:
-        return jdc.replace(
-            state,
-            observations=jnp.append(
-                # each row contains the location of one agent and the location of the target
-                jnp.column_stack((state.agents_locations, jnp.tile(self._target_location, (self.num_drones, 1)))),
-                # then we add agents_locations to each row without the agent which is already in the row
-                # and make it only one dimension
-                jnp.array([jnp.delete(state.agents_locations, agent, axis=0).flatten() for agent in range(self.num_drones)]),
-                axis=1,
-            ),
+    def _compute_obs(self, state: State) -> jnp.ndarray:
+        return jnp.append(
+            # each row contains the location of one agent and the location of the target
+            jnp.column_stack((state.agents_locations, jnp.tile(self._target_location, (self.num_drones, 1)))),
+            # then we add agents_locations to each row without the agent which is already in the row
+            # and make it only one dimension
+            jnp.array([jnp.delete(state.agents_locations, agent, axis=0).flatten() for agent in range(self.num_drones)]),
+            axis=1,
         )
 
     @override
@@ -88,31 +87,32 @@ class Surround(BaseParallelEnv):
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_reward(self, state: State) -> State:
+    def _compute_reward(self, state: State, terminations: jnp.ndarray, truncations: jnp.ndarray) -> jnp.ndarray:
         # Reward is the mean distance to the other agents plus a maximum value minus the distance to the target
 
-        return jdc.replace(
-            state,
-            rewards=jnp.any(state.truncations)
-            * (
-                jnp.array(
-                    [  # mean distance to the other agents
-                        jnp.sum(jnp.linalg.norm(state.agents_locations[agent] - state.agents_locations, axis=1))
-                        for agent in range(self.num_drones)
-                    ]
-                )
-                * 0.05
-                / (self.num_drones - 1)
-                # a maximum value minus the distance to the target
-                + 0.95 * (2 * self.size - jnp.linalg.norm(state.agents_locations - self._target_location, axis=1))
+        reward_close_to_target = 0.95 * (
+            2 * self.size - jnp.linalg.norm(state.agents_locations - self._target_location, axis=1)
+        )
+        reward_far_from_other_agents = (
+            jnp.array(
+                [
+                    jnp.sum(jnp.linalg.norm(state.agents_locations[agent] - state.agents_locations, axis=1))
+                    for agent in range(self.num_drones)
+                ]
             )
-            # negative reward if the drones crash
-            + jnp.any(state.terminations) * (1 - jnp.any(state.truncations)) * -10 * jnp.ones(self.num_drones),
+            * 0.05
+            / (self.num_drones - 1)
+        )
+        reward_crash = jnp.any(terminations) * -10 * jnp.ones(self.num_drones)
+
+        return (
+            jnp.any(truncations) * (reward_close_to_target + reward_far_from_other_agents)
+            + (1 - jnp.any(truncations)) * reward_crash
         )
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_terminated(self, state: State) -> State:
+    def _compute_terminated(self, state: State) -> jnp.ndarray:
         # collision with the ground and the target
         terminated = jnp.logical_or(
             state.agents_locations[:, 2] < 0.2, jnp.linalg.norm(state.agents_locations - self._target_location, axis=1) < 0.2
@@ -126,59 +126,22 @@ class Surround(BaseParallelEnv):
                 jnp.logical_or(terminated[agent], jnp.any(jnp.logical_and(distances > 0.001, distances < 0.2)))
             )
 
-        return jdc.replace(state, terminations=jnp.any(terminated) * jnp.ones(self.num_drones))
+        return jnp.any(terminated) * jnp.ones(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def _compute_truncation(self, state: State) -> State:
-        return jdc.replace(state, truncations=(state.timestep == 100) * jnp.ones(self.num_drones))
+    def _compute_truncation(self, state: State) -> jnp.ndarray:
+        return (state.timestep == 100) * jnp.ones(self.num_drones)
 
     @override
     @partial(jit, static_argnums=(0,))
-    def reset(self, key: jnp.ndarray) -> State:
+    def reset(self, key: jnp.ndarray) -> Tuple[jnp.ndarray, dict, State]:
         state = State(
             agents_locations=self._init_flying_pos,
             timestep=0,
-            observations=jnp.array([]),
-            rewards=jnp.zeros(self.num_drones),
-            terminations=jnp.zeros(self.num_drones),
-            truncations=jnp.zeros(self.num_drones),
         )
-        state = self._compute_obs(state)
-        return state
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def auto_reset(self, **state) -> State:
-        done = jnp.min(jnp.array([jnp.any(state["truncations"]) + jnp.any(state["terminations"]), 1]))
-
-        state = State(
-            agents_locations=done * self._init_flying_pos + (1 - done) * state["agents_locations"],
-            timestep=(1 - done) * state["timestep"],
-            observations=state["observations"],
-            rewards=(1 - done) * state["rewards"],
-            terminations=(1 - done) * state["terminations"],
-            truncations=(1 - done) * state["truncations"],
-        )
-        state = self._compute_obs(state)
-        return state
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def state_to_dict(self, state: State) -> dict:
-        return {
-            "agents_locations": state.agents_locations,
-            "timestep": state.timestep,
-            "observations": state.observations,
-            "rewards": state.rewards,
-            "terminations": state.terminations,
-            "truncations": state.truncations,
-        }
-
-    @override
-    @partial(jit, static_argnums=(0,))
-    def step_vmap(self, action: jnp.ndarray, key: jnp.ndarray, **state_val) -> State:
-        return self.step(State(**state_val), action, key)
+        obs = self._compute_obs(state)
+        return obs, {}, state
 
     @override
     @partial(jit, static_argnums=(0,))
@@ -193,8 +156,9 @@ if __name__ == "__main__":
 
     print(xla_bridge.get_backend().platform)
 
-    parallel_env = Surround(
-        num_drones=5,
+    num_agents = 5
+    env = Surround(
+        num_drones=num_agents,
         init_flying_pos=jnp.array([[0.0, 0.0, 1.0], [2.0, 1.0, 1.0], [0.0, 1.0, 1.0], [2.0, 2.0, 1.0], [1.0, 0.0, 1.0]]),
         target_location=jnp.array([[1.0, 1.0, 2.5]]),
     )
@@ -202,67 +166,34 @@ if __name__ == "__main__":
     num_envs = 1000  # number of states in parallel
     seed = 5  # test value
     key = random.PRNGKey(seed)
+    key, *subkeys = random.split(key, num_envs + 1)
 
-    vmapped_step = vmap(parallel_env.step_vmap)
-    vmapped_auto_reset = vmap(parallel_env.auto_reset)
-    vmapped_reset = vmap(parallel_env.reset)
+    # Wrappers
+    env = NormalizeObservation(env)
+    env = AddIDToObs(
+        env, num_agents
+    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
+    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
+    env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
+    env = VecEnv(env)  # vmaps the env public methods
+    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
 
-    @jit
-    def body(i, states_key):
-        """Body of the fori_loop of play.
+    obs, info, state = env.reset(jnp.stack(subkeys))
 
-        Args:
-            i: number of the iteration.
-            states_key: a tuple containing states and key.
-        """
-        states, key = states_key
-
-        key, *subkeys = random.split(key, parallel_env.num_drones + 1)
+    for i in range(301):
+        key, *subkeys = random.split(key, num_agents + 1)
         actions = (
-            jnp.array(
-                [parallel_env.action_space(agent_id).sample(subkeys[agent_id]) for agent_id in range(parallel_env.num_drones)]
-            )
+            jnp.array([env.action_space(agent_id).sample(jnp.stack(subkeys[agent_id])) for agent_id in range(env.num_drones)])
             .flatten()
             .repeat(num_envs)
-            .reshape((num_envs, parallel_env.num_drones, -1))
+            .reshape((num_envs, env.num_drones, -1))
         )
-
+        global_state = env.state(state)
         key, *subkeys = random.split(key, num_envs + 1)
+        obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
-        states = vmapped_step(actions, jnp.stack(subkeys), **parallel_env.state_to_dict(states))
-
-        # where you would learn or add to buffer
-
-        states = vmapped_auto_reset(**parallel_env.state_to_dict(states))
-
-        return (states, key)
-
-    @jit
-    def play(key):
-        """Execution of the environment with random actions."""
-        key, *subkeys = random.split(key, num_envs + 1)
-
-        states = vmapped_reset(jnp.stack(subkeys))
-
-        states, key = jax.lax.fori_loop(0, 1000, body, (states, key))
-
-        return key, states
-
-    key, states = play(key)  # compilation of the function
-
-    durations = np.zeros(10)
-
-    print("start")
-
-    for i in range(10):
-        start = time.time()
-
-        key, states = play(key)
-
-        jax.block_until_ready(states)
-
-        end = time.time() - start
-
-        durations[i] = end
-
-    print("durations : ", durations)
+        # print("obs", obs)
+        print("rewards", rewards)
+        # print("term", term)
+        print("trunc", trunc)
+        # print("info", info)

--- a/crazy_rl/test/test_numpy_and_jax.py
+++ b/crazy_rl/test/test_numpy_and_jax.py
@@ -21,11 +21,8 @@ def compare(state, jax_obs, jax_term, jax_trunc, jax_rewards, np_env, np_obs, np
     assert jax_trunc[0] == np_trunc["agent_0"]
     assert jax_trunc[1] == np_trunc["agent_1"]
 
-    assert jax_rewards[0] > np_rewards["agent_0"] - 0.01
-    assert jax_rewards[0] < np_rewards["agent_0"] + 0.01
-
-    assert jax_rewards[1] > np_rewards["agent_1"] - 0.01
-    assert jax_rewards[1] < np_rewards["agent_1"] + 0.01
+    assert np.allclose(np.asarray(jax_rewards[0]), np_rewards["agent_0"])
+    assert np.allclose(np.asarray(jax_rewards[1]), np_rewards["agent_1"])
 
 
 def test_np_jax():

--- a/crazy_rl/test/test_wrapper.py
+++ b/crazy_rl/test/test_wrapper.py
@@ -12,6 +12,21 @@ from crazy_rl.utils.jax_wrappers import (
 )
 
 
+def is_normalized(rewards, obs):
+    assert (rewards <= 1).all()
+    assert (rewards >= -1.1).all()
+
+    assert (obs <= 1).all()
+    assert (obs >= -1).all()
+
+
+def id_obs(obs):
+    assert obs[0][0][-2] == 1  # one more dimension because of parallelization
+    assert obs[0][0][-1] == 0
+    assert obs[0][1][-2] == 0
+    assert obs[0][1][-1] == 1
+
+
 def test_normalize():
     num_agents = 2
     env = Catch(
@@ -38,6 +53,8 @@ def test_normalize():
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 
+    id_obs(obs)
+
     assert (obs <= 1).all()
     assert (obs >= -1).all()
 
@@ -48,11 +65,9 @@ def test_normalize():
     key, *subkeys = random.split(key, num_envs + 1)
     obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))  # 0.2, 0.8
 
-    assert (rewards <= 1).all()
-    assert (rewards >= -1.1).all()
+    id_obs(obs)
 
-    assert (obs <= 1).all()
-    assert (obs >= -1).all()
+    is_normalized(rewards, obs)
 
     key, *subkeys = random.split(key, num_envs + 1)
     obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))  # 0.4, 0.6
@@ -62,11 +77,7 @@ def test_normalize():
     key, *subkeys = random.split(key, num_envs + 1)
     obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
-    assert (rewards <= 1).all()
-    assert (rewards >= -1.1).all()
-
-    assert (obs <= 1).all()
-    assert (obs >= -1).all()
+    is_normalized(rewards, obs)
 
     actions = jnp.array([[[0, 0, 0], [0, 0, 1]], [[0, 0, 0], [0, 0, 1]], [[0, 0, 0], [0, 0, 1]]])
 
@@ -74,8 +85,4 @@ def test_normalize():
         key, *subkeys = random.split(key, num_envs + 1)
         obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
 
-    assert (rewards <= 1).all()
-    assert (rewards >= -1.1).all()
-
-    assert (obs <= 1).all()
-    assert (obs >= -1).all()
+    is_normalized(rewards, obs)

--- a/crazy_rl/test/test_wrapper.py
+++ b/crazy_rl/test/test_wrapper.py
@@ -1,0 +1,81 @@
+import jax.numpy as jnp
+from jax import random
+
+from crazy_rl.multi_agent.jax.catch.catch import Catch
+from crazy_rl.utils.jax_wrappers import (
+    AddIDToObs,
+    AutoReset,
+    LogWrapper,
+    NormalizeVecObservation,
+    NormalizeVecReward,
+    VecEnv,
+)
+
+
+def test_normalize():
+    num_agents = 2
+    env = Catch(
+        num_drones=num_agents,
+        init_flying_pos=jnp.array([[0.0, 0.0, 1.0], [0.0, 1.0, 1.0]]),
+        init_target_location=jnp.array([1.0, 1.0, 2.5]),
+        target_speed=0.1,
+    )
+
+    num_envs = 3  # number of states in parallel
+    seed = 5  # test value
+    key = random.PRNGKey(seed)
+    key, *subkeys = random.split(key, num_envs + 1)
+
+    # Wrappers
+    env = AddIDToObs(
+        env, num_agents
+    )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
+    env = LogWrapper(env)  # Add stuff in the info dictionary for logging in the learning algo
+    env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
+    env = VecEnv(env)  # vmaps the env public methods
+    env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
+    env = NormalizeVecObservation(env)
+
+    obs, info, state = env.reset(jnp.stack(subkeys))
+
+    assert (obs <= 1).all()
+    assert (obs >= -1).all()
+
+    # The two drones crash
+
+    actions = jnp.array([[[0, 1, 0], [0, -1, 0]], [[0, 1, 0], [0, -1, 0]], [[0, 0, -1], [0, 0, 0]]])
+
+    key, *subkeys = random.split(key, num_envs + 1)
+    obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))  # 0.2, 0.8
+
+    assert (rewards <= 1).all()
+    assert (rewards >= -1.1).all()
+
+    assert (obs <= 1).all()
+    assert (obs >= -1).all()
+
+    key, *subkeys = random.split(key, num_envs + 1)
+    obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))  # 0.4, 0.6
+
+    actions = jnp.array([[[0, 0.5, 0], [0, 0, 0]], [[0, 0.5, 0], [0, 0, 0]], [[0, 0.5, 0], [0, 0, 0]]])
+
+    key, *subkeys = random.split(key, num_envs + 1)
+    obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
+
+    assert (rewards <= 1).all()
+    assert (rewards >= -1.1).all()
+
+    assert (obs <= 1).all()
+    assert (obs >= -1).all()
+
+    actions = jnp.array([[[0, 0, 0], [0, 0, 1]], [[0, 0, 0], [0, 0, 1]], [[0, 0, 0], [0, 0, 1]]])
+
+    for i in range(100):
+        key, *subkeys = random.split(key, num_envs + 1)
+        obs, rewards, term, trunc, info, state = env.step(state, actions, jnp.stack(subkeys))
+
+    assert (rewards <= 1).all()
+    assert (rewards >= -1.1).all()
+
+    assert (obs <= 1).all()
+    assert (obs >= -1).all()

--- a/crazy_rl/test/test_wrapper.py
+++ b/crazy_rl/test/test_wrapper.py
@@ -6,7 +6,7 @@ from crazy_rl.utils.jax_wrappers import (
     AddIDToObs,
     AutoReset,
     LogWrapper,
-    NormalizeVecObservation,
+    NormalizeObservation,
     NormalizeVecReward,
     VecEnv,
 )
@@ -27,6 +27,7 @@ def test_normalize():
     key, *subkeys = random.split(key, num_envs + 1)
 
     # Wrappers
+    env = NormalizeObservation(env)
     env = AddIDToObs(
         env, num_agents
     )  # concats the agent id as one hot encoded vector to the obs (easier for learning algorithms)
@@ -34,7 +35,6 @@ def test_normalize():
     env = AutoReset(env)  # Auto reset the env when done, stores additional info in the dict
     env = VecEnv(env)  # vmaps the env public methods
     env = NormalizeVecReward(env, gamma=0.99)  # normalize the reward in [-1, 1]
-    env = NormalizeVecObservation(env)
 
     obs, info, state = env.reset(jnp.stack(subkeys))
 

--- a/crazy_rl/utils/jax_wrappers.py
+++ b/crazy_rl/utils/jax_wrappers.py
@@ -230,7 +230,10 @@ class NormalizeObservation(Wrapper):
     def step(self, state, action, key):
         obs, reward, term, truncated, info, env_state = self._env.step(state, action, key)
 
-        obs = obs / self._env.observation_space(0).high
+        high = self._env.observation_space(0).high
+        low = self._env.observation_space(0).low
+
+        obs = -1 + (obs - low) * 2 / (high - low)  # min-max normalization
 
         return obs, reward, term, truncated, info, state
 

--- a/crazy_rl/utils/jax_wrappers.py
+++ b/crazy_rl/utils/jax_wrappers.py
@@ -27,14 +27,7 @@ class VecEnv(Wrapper):
     def __init__(self, env: BaseParallelEnv):
         super().__init__(env)
         self.reset = jax.vmap(self._env.reset, in_axes=(0,))
-        self.step = jax.vmap(
-            self._env.step,
-            in_axes=(
-                0,
-                0,
-                0,
-            ),
-        )
+        self.step = jax.vmap(self._env.step)
         self.state = jax.vmap(self._env.state, in_axes=(0,))
 
 

--- a/crazy_rl/utils/jax_wrappers.py
+++ b/crazy_rl/utils/jax_wrappers.py
@@ -236,10 +236,3 @@ class NormalizeObservation(Wrapper):
 
     def state(self, state: State) -> chex.Array:
         return self._env.state(state)
-
-
-# TODO class NormalizeObservation(Wrapper):
-# see: https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/wrappers.py#L193
-
-# TODO class NormalizeReward(Wrapper):
-# see: https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/wrappers.py#L270

--- a/crazy_rl/utils/jax_wrappers.py
+++ b/crazy_rl/utils/jax_wrappers.py
@@ -143,6 +143,73 @@ class AutoReset(Wrapper):
         return self._env.state(state)
 
 
+@struct.dataclass
+class NormalizeVecRewEnvState:
+    mean: jnp.ndarray
+    var: jnp.ndarray
+    count: float
+    return_val: float
+    env_state: State
+
+
+class NormalizeVecReward(Wrapper):
+    """Normalize the reward over a vectorized environment.
+
+    Taken and adapted from https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/wrappers.py
+    """
+
+    def __init__(self, env, gamma):
+        super().__init__(env)
+        self.gamma = gamma
+
+    def reset(self, key: chex.PRNGKey) -> Tuple[chex.Array, dict, NormalizeVecRewEnvState]:
+        obs, info, state = self._env.reset(key)
+        batch_count = obs.shape[0]
+        state = NormalizeVecRewEnvState(
+            mean=0.0,
+            var=1.0,
+            count=1e-4,
+            return_val=jnp.zeros((batch_count,)),
+            env_state=state,
+        )
+        return obs, info, state
+
+    def step(
+        self, state: chex.Array, action: chex.Array, key: chex.Array
+    ) -> Tuple[chex.Array, chex.Array, chex.Array, chex.Array, dict, NormalizeVecRewEnvState]:
+        obs, reward, term, truncated, info, env_state = self._env.step(state.env_state, action, key)
+        done = jnp.logical_or(jnp.any(term, axis=1), jnp.any(truncated, axis=1))
+        return_val = state.return_val * self.gamma * (1 - done) + reward.sum(
+            axis=1
+        )  # rewards are summed over agents (team reward)
+
+        batch_mean = jnp.mean(return_val, axis=0)
+        batch_var = jnp.var(return_val, axis=0)
+        batch_count = obs.shape[0]
+
+        delta = batch_mean - state.mean
+        tot_count = state.count + batch_count
+
+        new_mean = state.mean + delta * batch_count / tot_count
+        m_a = state.var * state.count
+        m_b = batch_var * batch_count
+        M2 = m_a + m_b + jnp.square(delta) * state.count * batch_count / tot_count
+        new_var = M2 / tot_count
+        new_count = tot_count
+
+        state = NormalizeVecRewEnvState(
+            mean=new_mean,
+            var=new_var,
+            count=new_count,
+            return_val=return_val,
+            env_state=env_state,
+        )
+        return obs, reward / jnp.sqrt(state.var + 1e-8), term, truncated, info, state
+
+    def state(self, state: NormalizeVecRewEnvState) -> chex.Array:
+        return self._env.state(state.env_state)
+
+
 # TODO class NormalizeObservation(Wrapper):
 # see: https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/wrappers.py#L193
 

--- a/crazy_rl/utils/jax_wrappers.py
+++ b/crazy_rl/utils/jax_wrappers.py
@@ -212,28 +212,30 @@ class NormalizeVecReward(Wrapper):
 
 
 class NormalizeObservation(Wrapper):
-    """Normalize the observation.
+    """Rescale the observation between low and high."""
 
-    Taken and adapted from https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/wrappers.py
-    """
-
-    def __init__(self, env):
+    def __init__(self, env, low=-1, high=1):
         super().__init__(env)
+        self.low = low
+        self.high = high
 
     def reset(self, key):
         obs, info, state = self._env.reset(key)
 
-        obs = obs / self._env.observation_space(0).high
+        max = self._env.observation_space(0).high
+        min = self._env.observation_space(0).low
+
+        obs = self.low + (obs - min) * (self.high - self.low) / (max - min)  # min-max normalization
 
         return obs, info, state
 
     def step(self, state, action, key):
         obs, reward, term, truncated, info, env_state = self._env.step(state, action, key)
 
-        high = self._env.observation_space(0).high
-        low = self._env.observation_space(0).low
+        max = self._env.observation_space(0).high
+        min = self._env.observation_space(0).low
 
-        obs = -1 + (obs - low) * 2 / (high - low)  # min-max normalization
+        obs = self.low + (obs - min) * (self.high - self.low) / (max - min)  # min-max normalization
 
         return obs, reward, term, truncated, info, state
 

--- a/crazy_rl/utils/jax_wrappers.py
+++ b/crazy_rl/utils/jax_wrappers.py
@@ -211,8 +211,8 @@ class NormalizeVecReward(Wrapper):
         return self._env.state(state.env_state)
 
 
-class NormalizeVecObservation(Wrapper):
-    """Normalize the observation over a vectorized environment.
+class NormalizeObservation(Wrapper):
+    """Normalize the observation.
 
     Taken and adapted from https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/wrappers.py
     """
@@ -234,7 +234,7 @@ class NormalizeVecObservation(Wrapper):
 
         return obs, reward, term, truncated, info, state
 
-    def state(self, state: NormalizeVecRewEnvState) -> chex.Array:
+    def state(self, state: State) -> chex.Array:
         return self._env.state(state)
 
 

--- a/crazy_rl/utils/jax_wrappers.py
+++ b/crazy_rl/utils/jax_wrappers.py
@@ -1,0 +1,127 @@
+"""This is based on Gymnax's wrappers.py, but modified to work with our multi-agent environments."""
+from functools import partial
+from typing import Tuple
+
+import chex
+import jax
+import jax.numpy as jnp
+from flax import struct
+
+from crazy_rl.multi_agent.jax.base_parallel_env import BaseParallelEnv, State
+
+
+class Wrapper:
+    """Base class for wrappers."""
+
+    def __init__(self, env: BaseParallelEnv):
+        self._env = env
+
+    # provide proxy access to regular attributes of wrapped object
+    def __getattr__(self, name):
+        return getattr(self._env, name)
+
+
+class VecEnv(Wrapper):
+    """Vectorized environment wrapper."""
+
+    def __init__(self, env: BaseParallelEnv):
+        super().__init__(env)
+        self.reset = jax.vmap(self._env.reset, in_axes=(0,))
+        self.step = jax.vmap(
+            self._env.step,
+            in_axes=(
+                0,
+                0,
+                0,
+            ),
+        )
+        self.state = jax.vmap(self._env.state, in_axes=(0,))
+
+
+@struct.dataclass
+class LogEnvState:
+    env_state: State
+    episode_returns: float
+    episode_lengths: int
+    returned_episode_returns: float
+    returned_episode_lengths: int
+    timestep: int
+
+
+class LogWrapper(Wrapper):
+    """Log the episode returns and lengths."""
+
+    def __init__(self, env: BaseParallelEnv):
+        super().__init__(env)
+
+    @partial(jax.jit, static_argnums=(0,))
+    def reset(self, key: chex.PRNGKey) -> Tuple[chex.Array, dict, LogEnvState]:
+        obs, info, env_state = self._env.reset(key)
+        state = LogEnvState(env_state, 0, 0, 0, 0, 0)
+        return obs, info, state
+
+    @partial(jax.jit, static_argnums=(0,))
+    def step(
+        self,
+        state: LogEnvState,
+        action: chex.Array,
+        key: chex.PRNGKey,
+    ) -> Tuple[chex.Array, chex.Array, chex.Array, chex.Array, dict, LogEnvState]:
+        obs, rewards, terminateds, truncateds, info, env_state = self._env.step(state.env_state, action, key)
+        done = jnp.logical_or(jnp.any(terminateds), jnp.any(truncateds))
+        new_episode_return = state.episode_returns + rewards.sum()  # rewards are summed over agents "team reward"
+        new_episode_length = state.episode_lengths + 1
+        state = LogEnvState(
+            env_state=env_state,
+            episode_returns=new_episode_return * (1 - done),
+            episode_lengths=new_episode_length * (1 - done),
+            returned_episode_returns=state.returned_episode_returns * (1 - done) + new_episode_return * done,
+            returned_episode_lengths=state.returned_episode_lengths * (1 - done) + new_episode_length * done,
+            timestep=state.timestep + 1,
+        )
+        info["returned_episode_returns"] = state.returned_episode_returns
+        info["returned_episode_lengths"] = state.returned_episode_lengths
+        info["timestep"] = state.timestep
+        info["returned_episode"] = done
+        return obs, rewards, terminateds, truncateds, info, state
+
+    def state(self, state: LogEnvState) -> chex.Array:
+        return self._env.state(state.env_state)
+
+
+class AddIDToObs(Wrapper):
+    """Add agent id to observation as one hot encoding."""
+
+    def __init__(self, env, num_agents):
+        super().__init__(env)
+        self.num_agents = num_agents
+
+    def _add_id(self, obs: jnp.ndarray) -> jnp.ndarray:
+        # one hot encoding of agent id
+        def _one_hot(id: int):
+            return jnp.eye(self.num_agents)[id]
+
+        return jnp.array([jnp.concatenate([o, _one_hot(id)]) for id, o in enumerate(obs)])
+
+    def reset(self, key: chex.PRNGKey) -> Tuple[chex.Array, dict, State]:
+        obs, info, state = self._env.reset(key)
+        return self._add_id(obs), info, state
+
+    def step(
+        self, state: State, action: jnp.ndarray, key: chex.PRNGKey
+    ) -> Tuple[chex.Array, chex.Array, chex.Array, chex.Array, dict, State]:
+        obs, rewards, term, trunc, info, state = self._env.step(state, action, key)
+        return self._add_id(obs), rewards, term, trunc, info, state
+
+    def state(self, state: State) -> chex.Array:
+        return self._env.state(state)
+
+
+# TODO class AutoReset(Wrapper):
+# see: https://github.com/google/brax/blob/main/brax/envs/wrappers/training.py#L96C1-L123C65
+
+# TODO class NormalizeObservation(Wrapper):
+# see: https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/wrappers.py#L193
+
+# TODO class NormalizeReward(Wrapper):
+# see: https://github.com/luchris429/purejaxrl/blob/main/purejaxrl/wrappers.py#L270


### PR DESCRIPTION
This new API aims at being more extensible (e.g. wrapping the env state to add more information such as the LogEnv wrapper). 

By returning the obs, rewards, term, trunc, info explicitly at each step, it allows to avoid playing with the state of the env to add additional information. This makes the code easier to extend.

I modified the catch example so there is a minimal example of code running with the wrappers.

Some of my changes:
- The new API returns the obs, rewards, term, trunc, info, state as a tuple
- Introduced some wrappers (see usage in the catch env)
- `VecEnv` -> automated wrapping to vectorize the environments -> autovmap
- `LogWrapper` -> automatically keeps track of the episode lengths and team reward for plotting while learning
- `AddIDToObs` -> concatenate the agent ID as a one-hot encoded vector to the obs, this allows the neural network to know who is currently playing


Next challenges:
- `AutoReset` as a wrapper: I think it is doable to actually have a wrapper doing the autoreset logic. It has been in Gymnasium and in Brax
- `NormalizeReward` & `NormalizeObs`: Algorithms often require normalization to work better. While I think normalizing the obs is not very hard (we have the bounds in the observation space), normalizing the rewards will probably require some moving avg tricks.